### PR TITLE
Add singledispatch benchmarks

### DIFF
--- a/microbenchmarks/singledispatch.py
+++ b/microbenchmarks/singledispatch.py
@@ -25,12 +25,12 @@ def calc_sum(x: Tree) -> int:
     raise TypeError("invalid type for x")
 
 
-@calc_sum.register
+@calc_sum.register(Leaf)
 def sum_leaf(x: Leaf) -> int:
     return 0
 
 
-@calc_sum.register
+@calc_sum.register(Node)
 def sum_node(x: Node) -> int:
     return x.value + calc_sum(x.left) + calc_sum(x.right)
 

--- a/microbenchmarks/singledispatch.py
+++ b/microbenchmarks/singledispatch.py
@@ -2,7 +2,7 @@ from functools import singledispatch
 
 from benchmarking import benchmark
 
-NUM_ITER = 100_000
+NUM_ITER = 500
 
 
 class Tree:

--- a/microbenchmarks/singledispatch.py
+++ b/microbenchmarks/singledispatch.py
@@ -1,63 +1,8 @@
 from functools import singledispatch
-from typing import Any
 
 from benchmarking import benchmark
 
 NUM_ITER = 100_000
-
-
-@singledispatch
-def f(arg) -> int:
-    return 1
-
-
-@f.register
-def g(arg: int) -> int:
-    return 2
-
-
-@benchmark
-def dynamic_dispatch_specialized() -> None:
-    x: Any = 5
-    # TODO: make sure the integer addition doesn't end up affecting benchmarking results
-    # (maybe remove addition if not necessary?)
-    n = 0
-    for i in range(NUM_ITER):
-        n += f(x)
-    # specialized implementation returns 2
-    assert n == NUM_ITER * 2, n
-
-
-@benchmark
-def dynamic_dispatch_fallback() -> None:
-    x: Any = "a"
-    n = 0
-    for i in range(NUM_ITER):
-        n += f(x)
-    assert n == NUM_ITER * 1, n
-
-
-# For situations that we know the type of the dispatch argument at compile time, we can probably
-# get a performance boost by skipping the runtime type check and inserting a call to the correct
-# implementation
-
-
-@benchmark
-def static_dispatch_specialized() -> None:
-    x: int = 5
-    n = 0
-    for i in range(NUM_ITER):
-        n += f(x)
-    assert n == NUM_ITER * 2, n
-
-
-@benchmark
-def static_dispatch_fallback() -> None:
-    x: str = "a"
-    n = 0
-    for i in range(NUM_ITER):
-        n += f(x)
-    assert n == NUM_ITER * 1, n
 
 
 class Tree:

--- a/microbenchmarks/singledispatch.py
+++ b/microbenchmarks/singledispatch.py
@@ -42,7 +42,7 @@ def build(n: int) -> Tree:
 
 
 @benchmark
-def sum_tree():
+def sum_tree_singledispatch():
     # making the tree too big causes building the tree to take too long or just crash python entirely
     tree = build(10)
     n: int = 0

--- a/microbenchmarks/singledispatch.py
+++ b/microbenchmarks/singledispatch.py
@@ -58,3 +58,51 @@ def static_dispatch_fallback() -> None:
     for i in range(NUM_ITER):
         n += f(x)
     assert n == NUM_ITER * 1, n
+
+
+class Tree:
+    pass
+
+
+class Leaf(Tree):
+    pass
+
+
+class Node(Tree):
+    def __init__(self, value: int, left: Tree, right: Tree) -> None:
+        self.value = value
+        self.left = left
+        self.right = right
+
+
+@singledispatch
+def calc_sum(x: Tree) -> int:
+    raise TypeError("invalid type for x")
+
+
+@calc_sum.register
+def sum_leaf(x: Leaf) -> int:
+    return 0
+
+
+@calc_sum.register
+def sum_node(x: Node) -> int:
+    return x.value + calc_sum(x.left) + calc_sum(x.right)
+
+
+def build(n: int) -> Tree:
+    if n == 0:
+        return Leaf()
+    return Node(n, build(n - 1), build(n - 1))
+
+
+@benchmark
+def sum_tree():
+    # making the tree too big causes building the tree to take too long or just crash python entirely
+    tree = build(10)
+    n: int = 0
+    for i in range(NUM_ITER):
+        n += calc_sum(tree)
+
+    # calc_sum(tree) should be 2036
+    assert n == NUM_ITER * 2036, n

--- a/microbenchmarks/singledispatch.py
+++ b/microbenchmarks/singledispatch.py
@@ -1,0 +1,60 @@
+from functools import singledispatch
+from typing import Any
+
+from benchmarking import benchmark
+
+NUM_ITER = 100_000
+
+
+@singledispatch
+def f(arg) -> int:
+    return 1
+
+
+@f.register
+def g(arg: int) -> int:
+    return 2
+
+
+@benchmark
+def dynamic_dispatch_specialized() -> None:
+    x: Any = 5
+    # TODO: make sure the integer addition doesn't end up affecting benchmarking results
+    # (maybe remove addition if not necessary?)
+    n = 0
+    for i in range(NUM_ITER):
+        n += f(x)
+    # specialized implementation returns 2
+    assert n == NUM_ITER * 2, n
+
+
+@benchmark
+def dynamic_dispatch_fallback() -> None:
+    x: Any = "a"
+    n = 0
+    for i in range(NUM_ITER):
+        n += f(x)
+    assert n == NUM_ITER * 1, n
+
+
+# For situations that we know the type of the dispatch argument at compile time, we can probably
+# get a performance boost by skipping the runtime type check and inserting a call to the correct
+# implementation
+
+
+@benchmark
+def static_dispatch_specialized() -> None:
+    x: int = 5
+    n = 0
+    for i in range(NUM_ITER):
+        n += f(x)
+    assert n == NUM_ITER * 2, n
+
+
+@benchmark
+def static_dispatch_fallback() -> None:
+    x: str = "a"
+    n = 0
+    for i in range(NUM_ITER):
+        n += f(x)
+    assert n == NUM_ITER * 1, n


### PR DESCRIPTION
This adds some benchmarks that measure the performance of calling a function that dispatches to an implementation using singledispatch.

There are 2 different situations that I added benchmarks for: when we don't know the type of the dispatch argument and when we do. For the first case, all we can probably do is just make the runtime type check and actual function call as fast as possible, but for the second case, we could probably get a performance boost by picking the right implementation at compile time and calling it directly, so it would be useful to have data for both cases.