### PR TITLE
Update supported platforms in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ all mypyc and mypy commits:
 
 Prerequisites:
 
-* Python 3.7 or later on Linux (or macOS?)
+* Python 3.7 or later on Linux, macOS, or Windows
 * `mypyc` in `PATH`
 * A working Python C development environment
 


### PR DESCRIPTION
This updates the list of supported platforms in the README to include Windows and macOS.

Windows support was added in #30, and #9 seems to suggest that running benchmarks on macOS works (although I don't have a Mac to test that on).