### PR TITLE
Add in_set and set_literal_iteration microbenchmarks

### DIFF
--- a/microbenchmarks/sets.py
+++ b/microbenchmarks/sets.py
@@ -1,0 +1,38 @@
+from typing import List, Tuple
+
+from benchmarking import benchmark
+
+
+@benchmark()
+def in_set() -> None:
+    a: List[Tuple[int, ...]] = []
+    for j in range(100):
+        for i in range(10):
+            a.append((i * 2,))
+            a.append((i, i + 2))
+            a.append((i,) * 6)
+            a.append(())
+
+    n = 0
+    for i in range(1000):
+        for s in a:
+            if 6 in s:
+                n += 1
+            if i in {3, 4, 5}:
+                n += 1
+    assert n == 412000, n
+
+
+@benchmark()
+def set_literal_iteration() -> None:
+    n = 0
+    for _ in range(1000):
+        for _ in range(10):
+            for i in {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}:
+                n += i
+            for s in {"yes", "no"}:
+                if s == "yes":
+                    n += 1
+            for a in {None, False, 1, 2.0, 3j, "4", b"5", (6,)}:
+                n += 1
+    assert n == 640000, n


### PR DESCRIPTION
I'm currently working on speeding up in operations against and iteration over  set literals so I was bound to create some microbenchmarks :)

Master (https://github.com/python/mypy/commit/98cc165a657a316accb93f1ed57fdc128b086d9f)

```
running in_set
..........
interpreted: 0.495790s (avg of 5 iterations; stdev 6.8%)
compiled:    0.810029s (avg of 5 iterations; stdev 1.5%)

compiled is 0.612x faster

running set_literal_iteration
.........................................................................................
interpreted: 0.020255s (avg of 45 iterations; stdev 2.5%)
compiled:    0.016336s (avg of 45 iterations; stdev 1.8%)

compiled is 1.240x faster
```

Needed for PR https://github.com/python/mypy/pull/14409