### PR TITLE
richards: Add missing Final

### DIFF
--- a/benchmarks/bm_richards.py
+++ b/benchmarks/bm_richards.py
@@ -150,7 +150,7 @@ class TaskState(object):
         return self.packet_pending and self.task_waiting and not self.task_holding
 
 
-tracing = False
+tracing: Final = False
 layout = 0
 
 


### PR DESCRIPTION
This makes the benchmark up to 40%(!) faster, since the variable
was used quite heavily.