### PR TITLE
Add memory allocation microbenchmarks

### DIFF
--- a/microbenchmarks/instances.py
+++ b/microbenchmarks/instances.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from benchmarking import benchmark
 
 
@@ -62,3 +64,79 @@ class Cls2(Base):
     def method(self, x: int) -> int:
         x = super(Cls2, self).method(x)
         return x + 1
+
+
+class Simple:
+    def __init__(self, x: int, y: int) -> None:
+        self.x = x
+        self.y = y
+
+    def update(self) -> Simple:
+        return Simple(self.y, self.x + 1)
+
+
+@benchmark()
+def alloc_short_lived_simple() -> None:
+    n = 0
+    for i in range(1000 * 1000):
+        s = Simple(i, 3)
+        s = s.update()
+        s = s.update()
+        s = s.update()
+        n += s.x
+    assert n == 4000000, n
+
+
+class Linked:
+    def __init__(self, x: int, next: Linked | None) -> None:
+        self.x = x
+        self.next = next
+
+    def sum(self) -> int:
+        n = self.x
+        o = self.next
+        while o:
+            n += o.x
+            o = o.next
+        return n
+
+
+@benchmark()
+def alloc_short_lived_linked() -> None:
+    n = 0
+    for i in range(1000 * 1000):
+        o = Linked(i, None)
+        o = Linked(1, o)
+        o = Linked(2, o)
+        o = Linked(3, o)
+        n += o.sum() & 7
+    assert n == 3500000, n
+
+
+@benchmark()
+def alloc_long_lived_simple() -> None:
+    a = []
+    for i in range(1000):
+        b = []
+        for j in range(1000):
+            b.append(Simple(j, i))
+        a.append(b)
+    n = 0
+    for b in a:
+        for s in b:
+            n += s.x
+    assert n == 499500000, n
+
+
+@benchmark()
+def alloc_long_lived_linked() -> None:
+    a = []
+    for i in range(100 * 1000):
+        o = Linked(i, None)
+        for j in range(10):
+            o = Linked(j, o)
+        a.append(o)
+    n = 0
+    for o in a:
+        n += o.sum()
+    assert n == 5004450000, n


### PR DESCRIPTION
Allocating and freeing instances is often a major bottleneck. Add microbenchmarks that model simplified versions of a few different scenarios. Add benchmarks for both short-lived and long-lived objects. The latter will likely spend more time in the cyclic GC. Also separately benchmark instances which don't need to participate in the cyclic GC. Currently all native classes participate in GC, but we could opt out classes from it in some cases.

We have other benchmarks that also heavily allocate objects, but it can still be useful to have dedicated microbenchmarks for this.