### PR TITLE
Use commit date, not author date

### DIFF
--- a/reporting/gitutil.py
+++ b/reporting/gitutil.py
@@ -52,13 +52,13 @@ def filter_commits_by_path(repo_dir: str, commits: List[str], prefix: str) -> Li
 
 
 def get_commit_times(repo_dir: str, commits: List[str]) -> Dict[str, Tuple[str, str]]:
-    cmd = ['git', 'show', '--numstat', '--date=unix'] + commits
+    cmd = ['git', 'show', '--numstat', '--pretty=fuller', '--date=unix'] + commits
     output = subprocess.check_output(cmd, cwd=repo_dir).decode("latin1")
     result = {}
     for line in output.splitlines():
         if line.startswith('commit '):
             commit = line.split()[1]
-        if line.startswith('Date: '):
+        if line.startswith('CommitDate: '):
             timestamp = int(line.split()[1])
             dt = datetime.utcfromtimestamp(timestamp)
             result[commit] = split_datetime(dt)


### PR DESCRIPTION
See https://github.com/python/mypy/commit/9ebe5fd49e4ea85cc9e64db99eef40634b780144 for an example of when this is necessary. Currently, in the [benchmark results](https://github.com/mypyc/mypyc-benchmark-results/blob/master/reports/benchmarks/mypy_self_check.md):

![image](https://github.com/mypyc/mypyc-benchmarks/assets/40616000/4646be20-f5f7-4d22-ac1c-d850af4ffea9)

This is confusing!! At least, I was confused. Anyways, hence this. This is untested other than finding the flag seems right.

Also `--numstat` seems unused.