### PR TITLE
Strip outliers less aggressively

### DIFF
--- a/benchmarks/mypy_self_check.py
+++ b/benchmarks/mypy_self_check.py
@@ -102,7 +102,7 @@ def prepare(mypy_repo: str | None) -> None:
     prepare=prepare,
     compiled_only=True,
     min_iterations=30,
-    strip_outlier_runs=False,
+    strip_outlier_runs=True,
     stable_hash_seed=True,
 )
 def mypy_self_check() -> None:

--- a/runbench.py
+++ b/runbench.py
@@ -58,7 +58,7 @@ def parse_elapsed_time(output: bytes) -> float:
 
 def smoothen(a: list[float]) -> list[float]:
     # Keep the lowest half of values
-    return sorted(a)[: (len(a) + 1) // 2]
+    return sorted(a)[: 2 * (len(a) + 1) // 3]
 
 
 


### PR DESCRIPTION
After running many benchmark in last few weeks I noticed that removing 1/3 of slowest runs results in lower noise levels. So I propose to try this as another experiment.