### PR TITLE
Asterisk on signifant perf change, if on different benchmark commit

### DIFF
--- a/reporting/report_runs.py
+++ b/reporting/report_runs.py
@@ -49,6 +49,8 @@ def gen_data_for_benchmark(baselines: List[DataItem],
             and change != -100.0
         ):
             perf_change = '%+.1f%%' % change
+            if item.benchmark_commit != baseline.benchmark_commit:
+                perf_change += "*"
         new_item = BenchmarkItem(
             date=commit_dates.get(item.mypy_commit, ("???", "???"))[0],
             perf=perf,


### PR DESCRIPTION
cc @JukkaL see https://github.com/python/mypy/pull/21119#issuecomment-4266543963 for context. I verified that `**+3.5%***` is rendered in Github as **+3.5%***, which looks good IMO.